### PR TITLE
Fix bug in braitenberg5 example

### DIFF
--- a/examples/braitenberg.pl
+++ b/examples/braitenberg.pl
@@ -63,5 +63,5 @@ braitenberg5 :-
     SpeedR is 40),
   ((LightL > 50, SpeedL is 100);
     SpeedL is 40),
-  motor_run('ev3-ports:'ev3-ports:outB'', SpeedL), motor_run('ev3-ports:outC', SpeedR), sleep(1),
+  motor_run('ev3-ports:outB', SpeedL), motor_run('ev3-ports:outC', SpeedR), sleep(1),
 braitenberg5.


### PR DESCRIPTION
The `'ev3-ports:outB'` is wrong on line 66, causing `braitenberg5` to not load correctly.